### PR TITLE
Skip build if SKIP_BUILD is defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,5 @@ run-onboard:
 	-v ${PWD}/onboard/input:/in:rw,Z \
 	-e PAGURE_TOKEN=${PAGURE_TOKEN} \
 	-e GITLAB_TOKEN=${GITLAB_TOKEN} \
+	-e SKIP_BUILD=${SKIP_BUILD} \
 	centos-onboard

--- a/pkg_survey/survey.py
+++ b/pkg_survey/survey.py
@@ -126,7 +126,7 @@ class CentosPkgValidatedConvert:
         if self.convert():
             self.run_srpm()
             self.result["size"] = (
-                subprocess.check_output(["du", "-s", self.src_dir])
+                subprocess.check_output(["du", "-sh", self.src_dir])
                 .split()[0]
                 .decode("utf-8")
             )
@@ -134,7 +134,7 @@ class CentosPkgValidatedConvert:
                 self.do_mock_build()
         else:
             self.result["size_rpms"] = (
-                subprocess.check_output(["du", "-s", self.rpm_dir])
+                subprocess.check_output(["du", "-sh", self.rpm_dir])
                 .split()[0]
                 .decode("utf-8")
             )

--- a/pkg_survey/survey.py
+++ b/pkg_survey/survey.py
@@ -123,13 +123,7 @@ class CentosPkgValidatedConvert:
                 }
             )
 
-        if not self.convert():
-            self.result["size_rpms"] = (
-                subprocess.check_output(["du", "-s", self.rpm_dir])
-                .split()[0]
-                .decode("utf-8")
-            )
-        else:
+        if self.convert():
             self.run_srpm()
             self.result["size"] = (
                 subprocess.check_output(["du", "-s", self.src_dir])
@@ -138,6 +132,12 @@ class CentosPkgValidatedConvert:
             )
             if self.srpm_path and not skip_build:
                 self.do_mock_build()
+        else:
+            self.result["size_rpms"] = (
+                subprocess.check_output(["du", "-s", self.rpm_dir])
+                .split()[0]
+                .decode("utf-8")
+            )
         if cleanup:
             self.cleanup()
 


### PR DESCRIPTION
This is useful if you want to onboard a package which has some minor build issue, like
- missing build dependency
- some failing test(s)

If you prove that it behaves the same even with the package being added to [VERY_VERY_HARD_PACKAGES](https://github.com/packit/dist-git-to-source-git/blob/master/dist2src/constants.py#L12) then it should be OK to onboard such package.