### PR TITLE
Push tags separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
+
 build-onboard:
-	podman build . -t centos-onboard -f onboard/Containerfile
+	$(CONTAINER_ENGINE) build . -t centos-onboard -f onboard/Containerfile
 
 run-onboard:
-	podman run --rm -ti --cap-add=SYS_ADMIN \
+	$(CONTAINER_ENGINE) run --rm -ti --cap-add=SYS_ADMIN \
 	-v ${HOME}/.ssh:/my-ssh:ro,Z \
 	-v ${PWD}/onboard/input:/in:rw,Z \
 	-v ${PWD}/onboard/onboard.py:/workdir/onboard.py:ro,Z \

--- a/onboard/onboard.py
+++ b/onboard/onboard.py
@@ -128,7 +128,8 @@ class OnboardCentosPKG:
 
         git_repo = Repo(converter.src_package_dir)
         git_repo.create_remote("packit", project.get_git_urls()["ssh"])
-        # dist2src update moves sg-start tag, we need --force to move it in remote
+        git_repo.git.push("packit", branch)
+        # dist2src update moves sg-start tag, we also need --force to move it in remote
         git_repo.git.push("packit", branch, tags=True, force=self.update)
 
         converter.cleanup()

--- a/pkg_survey/survey.py
+++ b/pkg_survey/survey.py
@@ -44,7 +44,9 @@ class CentosPkgValidatedConvert:
             r.git.checkout(self.distgit_branch)
             return True
         except Exception as ex:
-            if f"Remote branch {self.distgit_branch} not found" in str(ex):
+            if f"Remote branch {self.distgit_branch} not found" in str(
+                ex
+            ) or f"pathspec '{self.distgit_branch}' did not match" in str(ex):
                 return False
             self.result["package_name"] = self.package_name
             self.result["error"] = f"CloneError: {ex}"


### PR DESCRIPTION
Force pushes are forbidden, but force pushing tags only seems to be OK.

So we first push commits without force and then force push tags only.